### PR TITLE
Remove subcommands and groups mix error

### DIFF
--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -246,8 +246,6 @@ module Discordrb::Events
     # @yieldparam [SubcommandBuilder]
     # @return [ApplicationCommandEventHandler]
     def group(name)
-      raise ArgumentError, 'Unable to mix subcommands and groups' if @subcommands.any? { |_, v| v.is_a? Proc }
-
       builder = SubcommandBuilder.new(name)
       yield builder
 
@@ -259,8 +257,6 @@ module Discordrb::Events
     # @yieldparam [SubcommandBuilder]
     # @return [ApplicationCommandEventHandler]
     def subcommand(name, &block)
-      raise ArgumentError, 'Unable to mix subcommands and groups' if @subcommands.any? { |_, v| v.is_a? Hash }
-
       @subcommands[name.to_sym] = block
 
       self


### PR DESCRIPTION
# Summary

As described in [this issue](https://github.com/discordjs/builders/issues/25), these checks are not necessary. Mixing sub commands and command groups works as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/31e5dcb4-23d5-46bb-bcd3-e245047ab579)

I used the following code to validate it:
```ruby
require 'discordrb'
require 'dotenv/load'

bot = Discordrb::Bot.new(token: ENV.fetch('DISCORD_BOT_TOKEN', nil), intents: [])

bot.register_application_command(:example, 'Example commands') do |cmd|
  cmd.subcommand_group(:fun, 'Fun things!') do |group|
    group.subcommand('java', 'What if it was java?')
  end

  cmd.subcommand('test', 'this is not allowed, but should be')
end

bot.application_command(:example).subcommand('test') do |event|
  event.respond(content: 'this should work!')
end

bot.application_command(:example).group(:fun) do |group|
  group.subcommand('java') do |event|
    event.respond(content: 'this should work too!')
  end
end

bot.run```

Before my change, this would raise the 'Unable to mix subcommands and groups' error. After my change, this error no longer appears and the mixing of sub commands and groups works without issues.

## Removed / fixed
By removing this check, it is now possible to mix command groups and sub commands on the same command.
